### PR TITLE
Add `Source.Filter` configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Fetch or emit events to Datadog.
 
 * `api_key`: *Required.* The api key to use when accessing Datadog.
 
+* `filter`: *Optional.* Regexp to filter events by title when checking.
+
 
 ## Behavior
 
@@ -94,6 +96,7 @@ resources:
   source:
     api_key: API-KEY
     application_key: APPLICATION-KEY
+    filter: "event-.*-regexp"
 ```
 
 ### Plan

--- a/cmd/check/check_suite_test.go
+++ b/cmd/check/check_suite_test.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 
 	"bytes"
+
 	"github.com/concourse/datadog-event-resource/cmd"
 	"github.com/onsi/gomega/gexec"
 	"github.com/onsi/gomega/ghttp"
@@ -43,13 +44,13 @@ var _ = AfterEach(func() {
 	fakeDataDogServer.Close()
 })
 
-func RunCheckSuccessfully(id *string) *gexec.Session {
-	sess := RunCheck(id)
+func RunCheckSuccessfully(id *string, filter string) *gexec.Session {
+	sess := RunCheck(id, filter)
 	Expect(sess).To(gexec.Exit(0))
 	return sess
 }
 
-func RunCheck(id *string) *gexec.Session {
+func RunCheck(id *string, filter string) *gexec.Session {
 	var version *cmd.Version
 	if id != nil {
 		version = &cmd.Version{
@@ -61,6 +62,7 @@ func RunCheck(id *string) *gexec.Session {
 		Source: cmd.Source{
 			ApplicationKey: applicationKey,
 			ApiKey:         apiKey,
+			Filter:         filter,
 		},
 		Version: version,
 	}

--- a/cmd/cmd.go
+++ b/cmd/cmd.go
@@ -5,6 +5,7 @@ import "errors"
 type Source struct {
 	ApplicationKey string `json:"application_key"`
 	ApiKey         string `json:"api_key"`
+	Filter         string `json:"filter,omitempty"`
 }
 
 type Version struct {


### PR DESCRIPTION
Hello Concourse team,

We made this change to allow a check to trigger only if an event matches a given regexp.
It's part of our story: https://www.pivotaltracker.com/story/show/147838373

Thanks,

Signed-off-by: Claudia Beresford <cberesford@pivotal.io>