### PR TITLE
Add a note to README.md on potential concourse DB issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,3 +145,32 @@ docker build -t datadog-event-resource --targe tests -f dockerfiles/ubuntu/Docke
 
 Please make all pull requests to the `master` branch and ensure tests pass
 locally.
+
+## Caveats
+
+Unless you are planning on using datadog events for triggering jobs, make sure to disable automatic resource checking, like so:
+
+
+```yaml
+resources:
+- name: datadog-event
+  type: datadog-event
+  check_every: never
+  source:
+    api_key: API-KEY
+    application_key: APPLICATION-KEY
+```
+
+And in case you do plan on using datadog events to trigger jobs, make sure you're using event filtering:
+
+```yaml
+resources:
+- name: datadog-event
+  type: datadog-event
+  source:
+    api_key: API-KEY
+    application_key: APPLICATION-KEY
+    filter: "event-.*-regexp"
+```
+
+Otherwise you're running a risk of bloating the concourse database if the volume of events going through datadog is high enough.


### PR DESCRIPTION
I've received a report that our concourse cluster has become very slow. It quickly became apparent that the issue was related to the DB load. I've discovered that the `resource_config_versions` table has accumulated over 16 million entries, resulting in sequential scans when trying to view the resource versions page in concourse web UI. As it turned out, almost all of the entries were related to the `datadog-event` resource. We've been using the resource only to produce events, but I forgot to specify `check_every: never` on the resource definition.
I thought it might be helpful to include a note about this.